### PR TITLE
isOwnerOfResult or isPublicResult on getResult

### DIFF
--- a/src/main/java/com/iexec/core/result/ResultController.java
+++ b/src/main/java/com/iexec/core/result/ResultController.java
@@ -111,12 +111,12 @@ public class ResultController {
         Authorization auth = authorizationService.getAuthorizationFromToken(token);
 
         boolean isPublicResult = resultService.isPublicResult(chainTaskId, chainId);
-        boolean isOwnerOfResultAndAuthorized = auth != null
+        boolean isAuthorizedOwnerOfResult = auth != null
                 && resultService.isOwnerOfResult(chainId, chainTaskId, auth.getWalletAddress())
                 && authorizationService.isAuthorizationValid(auth);
 
-        if (isOwnerOfResultAndAuthorized || isPublicResult) {
-            if (isOwnerOfResultAndAuthorized) {
+        if (isAuthorizedOwnerOfResult || isPublicResult) {
+            if (isAuthorizedOwnerOfResult) {
                 challengeService.invalidateEip712ChallengeString(auth.getChallenge());
             }
 

--- a/src/main/java/com/iexec/core/result/ResultService.java
+++ b/src/main/java/com/iexec/core/result/ResultService.java
@@ -5,7 +5,6 @@ import com.iexec.common.chain.ChainDeal;
 import com.iexec.common.chain.ChainTask;
 import com.iexec.common.utils.BytesUtils;
 import com.iexec.core.chain.IexecHubService;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -84,44 +83,42 @@ public class ResultService {
         return org.apache.commons.io.IOUtils.toByteArray(result);
     }
 
-    boolean canGetResult(Integer chainId, String chainTaskId, String walletAddress) {
-        walletAddress = walletAddress.toLowerCase();
-        /*
-         * TODO 1:  Use an iexecHubService loaded with ResultRepo credentials
-         * TODO 2:  Make possible to call this iexecHubService with a 'chainId' at runtime
-         */
-        //THREE: check if requester (or beneficiary if set) equals address provided
-        Optional<ChainTask> chainTask = iexecHubService.getChainTask(chainTaskId);
-
-        if (!chainTask.isPresent()) {
-            log.error("Failed to get ChainTask [chainTaskId:{}, downloadRequester:{}]", chainTaskId, walletAddress);
+    /*
+     * TODO 1:  Use an iexecHubService loaded with ResultRepo credentials
+     * TODO 2:  Make possible to call this iexecHubService with a 'chainId' at runtime
+     */
+    boolean isOwnerOfResult(Integer chainId, String chainTaskId, String downloaderAddress) {
+        Optional<String> beneficiary = getBeneficiary(chainTaskId, chainId);
+        if (!beneficiary.isPresent()) {
+            log.error("Failed to get beneficiary for isOwnerOfResult() method [chainTaskId:{}, downloaderAddress:{}]",
+                    chainTaskId, downloaderAddress);
             return false;
         }
-
-        Optional<ChainDeal> chainDeal = iexecHubService.getChainDeal(chainTask.get().getDealid());
-        if (!chainDeal.isPresent()) {
-            log.error("Failed to get ChainDeal [chainTaskId:{}, downloadRequester:{}]", chainTaskId, walletAddress);
+        downloaderAddress = downloaderAddress.toLowerCase();
+        if (!downloaderAddress.equals(beneficiary.get())) {
+            log.error("Set beneficiary doesn't match downloaderAddress [chainTaskId:{}, downloaderAddress:{}, " +
+                    "beneficiary:{}]", chainTaskId, downloaderAddress, beneficiary.get());
             return false;
         }
-
-        String requester = chainDeal.get().getRequester();
-        String beneficiary = chainDeal.get().getBeneficiary();
-
-        if (!beneficiary.equals(BytesUtils.EMPTY_ADDRESS) && !walletAddress.equalsIgnoreCase(beneficiary)) {
-            log.error("Set beneficiary doesn't match downloadRequester [chainTaskId:{}, downloadRequester:{}," +
-                            "requester:{}, beneficiary:{}]",
-                    chainTaskId, walletAddress, requester, beneficiary);
-            return false;
-        }
-
-        if (!walletAddress.equalsIgnoreCase(requester)) {
-            log.error("Set requester doesn't match downloadRequester [chainTaskId:{}, downloadRequester:{}," +
-                            "requester:{}, beneficiary:{}]",
-                    chainTaskId, walletAddress, requester, beneficiary);
-            return false;
-        }
-
         return true;
+    }
+
+    boolean isPublicResult(String chainTaskId, Integer chainId) {
+        Optional<String> beneficiary = getBeneficiary(chainTaskId, chainId);
+        if (!beneficiary.isPresent()) {
+            log.error("Failed to get beneficiary for isPublicResult() method [chainTaskId:{}]", chainTaskId);
+            return false;
+        }
+        return beneficiary.get().equals(BytesUtils.EMPTY_ADDRESS);
+    }
+
+    private Optional<String> getBeneficiary(String chainTaskId, Integer chainId) {
+        Optional<ChainTask> chainTask = iexecHubService.getChainTask(chainTaskId);
+        if (!chainTask.isPresent()) {
+            return Optional.empty();
+        }
+        Optional<ChainDeal> optionalChainDeal = iexecHubService.getChainDeal(chainTask.get().getDealid());
+        return optionalChainDeal.map(chainDeal -> chainDeal.getBeneficiary().toLowerCase());
     }
 
 }

--- a/src/test/java/com/iexec/core/result/ResultServiceTest.java
+++ b/src/test/java/com/iexec/core/result/ResultServiceTest.java
@@ -161,14 +161,14 @@ public class ResultServiceTest {
         String beneficiary = BytesUtils.EMPTY_ADDRESS;
         when(iexecHubService.getChainTask("0x1")).thenReturn(Optional.of(ChainTask.builder().dealid(chainDealId).build()));
         when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.of(ChainDeal.builder().requester(requester).beneficiary(beneficiary).build()));
-        assertThat(resultService.canGetResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
+        assertThat(resultService.isOwnerOfResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
     }
 
     @Test
     public void isNotAuthorizedToGetResultSinceCannotGetChainTask() {
         when(iexecHubService.getChainTask("0x1")).thenReturn(Optional.empty());
 
-        assertThat(resultService.canGetResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
+        assertThat(resultService.isOwnerOfResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
     }
 
     @Test
@@ -176,33 +176,46 @@ public class ResultServiceTest {
         when(iexecHubService.getChainTask("0x1")).thenReturn(Optional.of(ChainTask.builder().dealid(chainDealId).build()));
         when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.empty());
 
-        assertThat(resultService.canGetResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
+        assertThat(resultService.isOwnerOfResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
     }
 
     @Test
-    public void isNotAuthorizedToGetResultSinceWalletAddressDifferentFromBeneficiary() {
-        String requester = "0xa";
+    public void isNotOwnerOfResultSinceWalletAddressDifferentFromBeneficiary() {
         String beneficiary = "0xb";
         when(iexecHubService.getChainTask("0x1")).thenReturn(Optional.of(ChainTask.builder().dealid(chainDealId).build()));
-        when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.of(ChainDeal.builder().requester(requester).beneficiary(beneficiary).build()));
-        assertThat(resultService.canGetResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
+        when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.of(ChainDeal.builder().beneficiary(beneficiary).build()));
+        assertThat(resultService.isOwnerOfResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
     }
 
     @Test
-    public void isNotAuthorizedToGetResultSinceWalletAddressShouldBeBeneficiaryWhenSet() {
-        String requester = "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E";
+    public void isNotOwnerOfResultSinceWalletAddressShouldBeBeneficiary() {
         String beneficiary = "0xb";
         when(iexecHubService.getChainTask("0x1")).thenReturn(Optional.of(ChainTask.builder().dealid(chainDealId).build()));
-        when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.of(ChainDeal.builder().requester(requester).beneficiary(beneficiary).build()));
-        assertThat(resultService.canGetResult(chainId, chainTaskId,"0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
+        when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.of(ChainDeal.builder().beneficiary(beneficiary).build()));
+        assertThat(resultService.isOwnerOfResult(chainId, chainTaskId,"0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isFalse();
     }
 
     @Test
-    public void isAuthorizedToGetResult() {
-        String requester = "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E";
+    public void isOwnerOfResult() {
+        String beneficiary = "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E";
+        when(iexecHubService.getChainTask(chainTaskId)).thenReturn(Optional.of(ChainTask.builder().dealid(chainDealId).build()));
+        when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.of(ChainDeal.builder().beneficiary(beneficiary).build()));
+        assertThat(resultService.isOwnerOfResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isTrue();
+    }
+
+    @Test
+    public void isPublicResult() {
         String beneficiary = BytesUtils.EMPTY_ADDRESS;
         when(iexecHubService.getChainTask(chainTaskId)).thenReturn(Optional.of(ChainTask.builder().dealid(chainDealId).build()));
-        when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.of(ChainDeal.builder().requester(requester).beneficiary(beneficiary).build()));
-        assertThat(resultService.canGetResult(chainId, chainTaskId, "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E")).isTrue();
+        when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.of(ChainDeal.builder().beneficiary(beneficiary).build()));
+        assertThat(resultService.isPublicResult(chainTaskId, chainId)).isTrue();
+    }
+
+    @Test
+    public void isNotPublicResult() {
+        String beneficiary = "0xb";
+        when(iexecHubService.getChainTask(chainTaskId)).thenReturn(Optional.of(ChainTask.builder().dealid(chainDealId).build()));
+        when(iexecHubService.getChainDeal(chainDealId)).thenReturn(Optional.of(ChainDeal.builder().beneficiary(beneficiary).build()));
+        assertThat(resultService.isPublicResult(chainTaskId, chainId)).isFalse();
     }
 }


### PR DESCRIPTION
When getResult on the ResultRepo:
If beneficiary is not set, then result is available to anyone
If beneficiary is set, the downloader should be the beneficiary

There's no more 'requester' involved in the getResult process