### PR TITLE
Move all fail statuses to ERROR

### DIFF
--- a/src/main/java/com/iexec/core/task/Task.java
+++ b/src/main/java/com/iexec/core/task/Task.java
@@ -92,6 +92,11 @@ public class Task {
         return this.getDateStatusList().get(this.getDateStatusList().size() - 1);
     }
 
+    @JsonIgnore
+    public TaskStatus getLastButOneStatus() {
+        return this.getDateStatusList().get(this.getDateStatusList().size() - 2).getStatus();
+    }
+
     public boolean isConsensusReachedSinceMultiplePeriods(int nbOfPeriods) {
         Optional<Date> consensusReachedDate = this.getDateOfStatus(CONSENSUS_REACHED);
         if (!consensusReachedDate.isPresent()){

--- a/src/main/java/com/iexec/core/task/TaskRepository.java
+++ b/src/main/java/com/iexec/core/task/TaskRepository.java
@@ -21,6 +21,8 @@ interface TaskRepository extends MongoRepository<Task, String> {
     List<Task> findByCurrentStatus(TaskStatus status);
 
     @Query("{ 'currentStatus': {$in: ?0} }")
-    List<Task> findByCurrentStatus(List<TaskStatus> status);
+    List<Task> findByCurrentStatus(List<TaskStatus> statuses);
 
+    @Query("{ 'currentStatus': {$nin: ?0} }")
+    List<Task> findByCurrentStatusNotIn(List<TaskStatus> statuses);    
 }

--- a/src/main/java/com/iexec/core/task/TaskService.java
+++ b/src/main/java/com/iexec/core/task/TaskService.java
@@ -88,15 +88,8 @@ public class TaskService {
         return taskRepository.findByCurrentStatus(Arrays.asList(INITIALIZED, RUNNING));
     }
 
-    private List<Task> getNotYetFinishedTasks() {
-        return taskRepository.findByCurrentStatus(Arrays.asList(
-                RUNNING,
-                CONTRIBUTION_TIMEOUT,
-                CONSENSUS_REACHED,
-                AT_LEAST_ONE_REVEALED,
-                REVEALED,
-                RESULT_UPLOAD_REQUESTED,
-                RESULT_UPLOADING));
+    private List<Task> getTasksInNonFinalStatus() {
+        return taskRepository.findByCurrentStatusNotIn(Arrays.asList(ERROR, COMPLETED));
     }
 
     // in case the task has been modified between reading and writing it, it is retried up to 5 times

--- a/src/main/java/com/iexec/core/task/TaskService.java
+++ b/src/main/java/com/iexec/core/task/TaskService.java
@@ -379,7 +379,7 @@ public class TaskService {
 
         if (condition1 && condition2) {
             updateTaskStatusAndSave(task, RESULT_UPLOADED);
-            updateResultUploaded2Finalized(task);
+            resultUploaded2Finalized2Completed(task);
         } else if (replicatesService.getNbReplicatesWithCurrentStatus(task.getChainTaskId(), ReplicateStatus.RESULT_UPLOAD_REQUEST_FAILED) > 0 &&
                 replicatesService.getNbReplicatesWithCurrentStatus(task.getChainTaskId(), ReplicateStatus.RESULT_UPLOADING) == 0) {
             // need to request upload again

--- a/src/main/java/com/iexec/core/task/TaskService.java
+++ b/src/main/java/com/iexec/core/task/TaskService.java
@@ -88,7 +88,7 @@ public class TaskService {
         return taskRepository.findByCurrentStatus(Arrays.asList(INITIALIZED, RUNNING));
     }
 
-    private List<Task> getTasksInNonFinalStatus() {
+    private List<Task> getTasksInNonFinalStatuses() {
         return taskRepository.findByCurrentStatusNotIn(Arrays.asList(FAILED, COMPLETED));
     }
 
@@ -295,6 +295,7 @@ public class TaskService {
 
         if (isInitializedOrRunningTask && isChainTaskActive && isNowAfterContributionDeadline) {
             updateTaskStatusAndSave(task, CONTRIBUTION_TIMEOUT);
+            updateTaskStatusAndSave(task, FAILED);
             applicationEventPublisher.publishEvent(ContributionTimeoutEvent.builder()
                     .chainTaskId(task.getChainTaskId())
                     .build());

--- a/src/main/java/com/iexec/core/task/TaskService.java
+++ b/src/main/java/com/iexec/core/task/TaskService.java
@@ -6,6 +6,7 @@ import com.iexec.common.chain.ChainTaskStatus;
 import com.iexec.common.replicate.ReplicateStatus;
 import com.iexec.common.tee.TeeUtils;
 import com.iexec.core.chain.IexecHubService;
+import com.iexec.core.configuration.ResultRepositoryConfiguration;
 import com.iexec.core.replicate.Replicate;
 import com.iexec.core.replicate.ReplicatesService;
 import com.iexec.core.task.event.ConsensusReachedEvent;
@@ -35,31 +36,25 @@ import static com.iexec.core.task.TaskStatus.*;
 @Service
 public class TaskService {
 
-    @Value("${resultRepository.protocol}")
-    private String resultRepositoryProtocol;
-
-    @Value("${resultRepository.ip}")
-    private String resultRepositoryIp;
-
-    @Value("${resultRepository.port}")
-    private String resultRepositoryPort;
-
     private TaskRepository taskRepository;
     private WorkerService workerService;
     private IexecHubService iexecHubService;
     private ReplicatesService replicatesService;
     private ApplicationEventPublisher applicationEventPublisher;
+    private ResultRepositoryConfiguration resultRepositoryConfig;
 
     public TaskService(TaskRepository taskRepository,
                        WorkerService workerService,
                        IexecHubService iexecHubService,
                        ReplicatesService replicatesService,
-                       ApplicationEventPublisher applicationEventPublisher) {
+                       ApplicationEventPublisher applicationEventPublisher,
+                       ResultRepositoryConfiguration resultRepositoryConfig) {
         this.taskRepository = taskRepository;
         this.workerService = workerService;
         this.iexecHubService = iexecHubService;
         this.replicatesService = replicatesService;
         this.applicationEventPublisher = applicationEventPublisher;
+        this.resultRepositoryConfig = resultRepositoryConfig;
     }
 
     public Optional<Task> addTask(String chainDealId, int taskIndex, String imageName, String commandLine, int trust, long maxExecutionTime, String tag) {
@@ -89,8 +84,19 @@ public class TaskService {
         return taskRepository.findByChainDealIdAndTaskIndex(chainDealId, taskIndex);
     }
 
-    private List<Task> getAllRunningTasks() {
+    private List<Task> getInitializedOrRunningTasks() {
         return taskRepository.findByCurrentStatus(Arrays.asList(INITIALIZED, RUNNING));
+    }
+
+    private List<Task> getNotYetFinishedTasks() {
+        return taskRepository.findByCurrentStatus(Arrays.asList(
+                RUNNING,
+                CONTRIBUTION_TIMEOUT,
+                CONSENSUS_REACHED,
+                AT_LEAST_ONE_REVEALED,
+                REVEALED,
+                RESULT_UPLOAD_REQUESTED,
+                RESULT_UPLOADING));
     }
 
     // in case the task has been modified between reading and writing it, it is retried up to 5 times
@@ -104,7 +110,7 @@ public class TaskService {
         Worker worker = optional.get();
 
         // return empty if there is no task to contribute
-        List<Task> runningTasks = getAllRunningTasks();
+        List<Task> runningTasks = getInitializedOrRunningTasks();
         if (runningTasks.isEmpty()) {
             return Optional.empty();
         }
@@ -167,7 +173,7 @@ public class TaskService {
                 resultUploading2UploadTimeout(task);
                 break;
             case RESULT_UPLOADED:
-                updateResultUploaded2Finalized(task);
+                resultUploaded2Finalized2Completed(task);
                 break;
         }
     }
@@ -188,7 +194,7 @@ public class TaskService {
         boolean isCurrentStatusReceived = task.getCurrentStatus().equals(RECEIVED);
 
         if (!isCurrentStatusReceived) {
-            log.error("Initialize failed [chainTaskId:{}, currentStatus:{}]",
+            log.error("Cannot initialize [chainTaskId:{}, currentStatus:{}]",
                     task.getChainTaskId(), task.getCurrentStatus());
             return;
         }
@@ -219,6 +225,8 @@ public class TaskService {
             log.error("Initialize failed [existingChainTaskId:{}, returnedChainTaskId:{}]",
                     existingChainTaskId, chainTaskId);
             updateTaskStatusAndSave(task, INITIALIZE_FAILED);
+            updateTaskStatusAndSave(task, ERROR);
+            return;
         }
 
         Optional<ChainTask> optional = iexecHubService.getChainTask(chainTaskId);
@@ -328,24 +336,25 @@ public class TaskService {
             return;
         }
 
-        updateTaskStatusAndSave(task, TaskStatus.REOPENING);
+        updateTaskStatusAndSave(task, REOPENING);
         Optional<ChainReceipt> optionalChainReceipt = iexecHubService.reOpen(task.getChainTaskId());
 
         if (!optionalChainReceipt.isPresent()) {
             log.error("Reopen failed [chainTaskId:{}, canReopen:{}, hasEnoughGas:{}]",
                     task.getChainTaskId(), canReopen, hasEnoughGas);
-            updateTaskStatusAndSave(task, TaskStatus.REOPEN_FAILED);
+            updateTaskStatusAndSave(task, REOPEN_FAILED);
+            updateTaskStatusAndSave(task, ERROR);
             return;
         }
 
         task.setConsensus(null);
         task.setRevealDeadline(new Date(0));
-        updateTaskStatusAndSave(task, TaskStatus.REOPENED, optionalChainReceipt.get());
-        updateTaskStatusAndSave(task, TaskStatus.INITIALIZED, optionalChainReceipt.get());
+        updateTaskStatusAndSave(task, REOPENED, optionalChainReceipt.get());
+        updateTaskStatusAndSave(task, INITIALIZED, optionalChainReceipt.get());
     }
 
     private void uploadRequested2UploadingResult(Task task) {
-        boolean isTaskInUploadRequested = task.getCurrentStatus().equals(TaskStatus.RESULT_UPLOAD_REQUESTED);
+        boolean isTaskInUploadRequested = task.getCurrentStatus().equals(RESULT_UPLOAD_REQUESTED);
         boolean isThereAWorkerUploading = replicatesService.getNbReplicatesWithCurrentStatus(task.getChainTaskId(), ReplicateStatus.RESULT_UPLOADING) > 0;
 
         if (isTaskInUploadRequested) {
@@ -358,19 +367,21 @@ public class TaskService {
     }
 
     private void uploadRequested2UploadRequestTimeout(Task task) {
-        boolean isTaskInUploadRequested = task.getCurrentStatus().equals(TaskStatus.RESULT_UPLOAD_REQUESTED);
-        boolean isNowAfterFinalDeadline = task.getFinalDeadline() != null && new Date().after(task.getFinalDeadline());
+        boolean isTaskInUploadRequested = task.getCurrentStatus().equals(RESULT_UPLOAD_REQUESTED);
+        boolean isNowAfterFinalDeadline = task.getFinalDeadline() != null
+                                        && new Date().after(task.getFinalDeadline());
 
         if (isTaskInUploadRequested && isNowAfterFinalDeadline) {
             updateTaskStatusAndSave(task, RESULT_UPLOAD_REQUEST_TIMEOUT);
             applicationEventPublisher.publishEvent(ResultUploadTimeoutEvent.builder()
                     .chainTaskId(task.getChainTaskId())
                     .build());
+            updateTaskStatusAndSave(task, ERROR);
         }
     }
 
     private void resultUploading2Uploaded(Task task) {
-        boolean condition1 = task.getCurrentStatus().equals(TaskStatus.RESULT_UPLOADING);
+        boolean condition1 = task.getCurrentStatus().equals(RESULT_UPLOADING);
         boolean condition2 = replicatesService.getNbReplicatesContainingStatus(task.getChainTaskId(), ReplicateStatus.RESULT_UPLOADED) > 0;
 
         if (condition1 && condition2) {
@@ -384,14 +395,16 @@ public class TaskService {
     }
 
     private void resultUploading2UploadTimeout(Task task) {
-        boolean isTaskInResultUploading = task.getCurrentStatus().equals(TaskStatus.RESULT_UPLOADING);
-        boolean isNowAfterFinalDeadline = task.getFinalDeadline() != null && new Date().after(task.getFinalDeadline());
+        boolean isTaskInResultUploading = task.getCurrentStatus().equals(RESULT_UPLOADING);
+        boolean isNowAfterFinalDeadline = task.getFinalDeadline() != null
+                                        && new Date().after(task.getFinalDeadline());
 
         if (isTaskInResultUploading && isNowAfterFinalDeadline) {
             updateTaskStatusAndSave(task, RESULT_UPLOAD_TIMEOUT);
             applicationEventPublisher.publishEvent(ResultUploadTimeoutEvent.builder()
                     .chainTaskId(task.getChainTaskId())
                     .build());
+            updateTaskStatusAndSave(task, ERROR);
         }
     }
 
@@ -409,7 +422,7 @@ public class TaskService {
         }
     }
 
-    private void updateResultUploaded2Finalized(Task task) {
+    private void resultUploaded2Finalized2Completed(Task task) {
         boolean isTaskInResultUploaded = task.getCurrentStatus().equals(RESULT_UPLOADED);
         boolean canFinalize = iexecHubService.canFinalize(task.getChainTaskId());
 
@@ -432,26 +445,21 @@ public class TaskService {
         }
 
         updateTaskStatusAndSave(task, FINALIZING);
-        String resultUri = resultRepositoryProtocol + "://" + resultRepositoryIp + ":" + resultRepositoryPort + "/results/" + task.getChainTaskId();
+        String resultUri = resultRepositoryConfig.getResultRepositoryURL()
+                + "/results/" + task.getChainTaskId();
         Optional<ChainReceipt> optionalChainReceipt = iexecHubService.finalizeTask(task.getChainTaskId(), resultUri);
 
         if (!optionalChainReceipt.isPresent()) {
             log.error("Finalize failed [chainTaskId:{} canFinalize:{}, isAfterRevealDeadline:{}, hasAtLeastOneReveal:{}]",
                     task.getChainTaskId(), isTaskInResultUploaded, canFinalize, offChainRevealEqualsOnChainReveal);
             updateTaskStatusAndSave(task, FINALIZE_FAILED);
+            updateTaskStatusAndSave(task, ERROR);
             return;
         }
 
         updateTaskStatusAndSave(task, FINALIZED, optionalChainReceipt.get());
-        updateFromFinalizedToCompleted(task);
+
+        updateTaskStatusAndSave(task, COMPLETED);
+        applicationEventPublisher.publishEvent(new TaskCompletedEvent(task));
     }
-
-    private void updateFromFinalizedToCompleted(Task task) {
-        if (task.getCurrentStatus().equals(FINALIZED)) {
-            updateTaskStatusAndSave(task, COMPLETED);
-
-            applicationEventPublisher.publishEvent(new TaskCompletedEvent(task));
-        }
-    }
-
 }

--- a/src/main/java/com/iexec/core/task/TaskService.java
+++ b/src/main/java/com/iexec/core/task/TaskService.java
@@ -89,7 +89,7 @@ public class TaskService {
     }
 
     private List<Task> getTasksInNonFinalStatus() {
-        return taskRepository.findByCurrentStatusNotIn(Arrays.asList(ERROR, COMPLETED));
+        return taskRepository.findByCurrentStatusNotIn(Arrays.asList(FAILED, COMPLETED));
     }
 
     // in case the task has been modified between reading and writing it, it is retried up to 5 times
@@ -218,7 +218,7 @@ public class TaskService {
             log.error("Initialize failed [existingChainTaskId:{}, returnedChainTaskId:{}]",
                     existingChainTaskId, chainTaskId);
             updateTaskStatusAndSave(task, INITIALIZE_FAILED);
-            updateTaskStatusAndSave(task, ERROR);
+            updateTaskStatusAndSave(task, FAILED);
             return;
         }
 
@@ -336,7 +336,7 @@ public class TaskService {
             log.error("Reopen failed [chainTaskId:{}, canReopen:{}, hasEnoughGas:{}]",
                     task.getChainTaskId(), canReopen, hasEnoughGas);
             updateTaskStatusAndSave(task, REOPEN_FAILED);
-            updateTaskStatusAndSave(task, ERROR);
+            updateTaskStatusAndSave(task, FAILED);
             return;
         }
 
@@ -369,7 +369,7 @@ public class TaskService {
             applicationEventPublisher.publishEvent(ResultUploadTimeoutEvent.builder()
                     .chainTaskId(task.getChainTaskId())
                     .build());
-            updateTaskStatusAndSave(task, ERROR);
+            updateTaskStatusAndSave(task, FAILED);
         }
     }
 
@@ -397,7 +397,7 @@ public class TaskService {
             applicationEventPublisher.publishEvent(ResultUploadTimeoutEvent.builder()
                     .chainTaskId(task.getChainTaskId())
                     .build());
-            updateTaskStatusAndSave(task, ERROR);
+            updateTaskStatusAndSave(task, FAILED);
         }
     }
 
@@ -446,7 +446,7 @@ public class TaskService {
             log.error("Finalize failed [chainTaskId:{} canFinalize:{}, isAfterRevealDeadline:{}, hasAtLeastOneReveal:{}]",
                     task.getChainTaskId(), isTaskInResultUploaded, canFinalize, offChainRevealEqualsOnChainReveal);
             updateTaskStatusAndSave(task, FINALIZE_FAILED);
-            updateTaskStatusAndSave(task, ERROR);
+            updateTaskStatusAndSave(task, FAILED);
             return;
         }
 

--- a/src/main/java/com/iexec/core/task/TaskStatus.java
+++ b/src/main/java/com/iexec/core/task/TaskStatus.java
@@ -25,7 +25,7 @@ public enum TaskStatus {
     FINALIZED,
     FINALIZE_FAILED,
     COMPLETED,
-    ERROR;
+    FAILED;
 
     public static List<TaskStatus> getWaitingRevealStatuses() {
         return Arrays.asList(

--- a/src/main/java/com/iexec/core/workflow/TaskWorkflow.java
+++ b/src/main/java/com/iexec/core/workflow/TaskWorkflow.java
@@ -27,6 +27,6 @@ public class TaskWorkflow extends Workflow<TaskStatus> {
         addTransition(RESULT_UPLOAD_REQUESTED, RESULT_UPLOADING);
         addTransition(RESULT_UPLOADING, RESULT_UPLOADED);
         addTransition(RESULT_UPLOADED, COMPLETED);
-        addTransition(RESULT_UPLOADING, ERROR);
+        addTransition(RESULT_UPLOADING, FAILED);
     }
 }

--- a/src/test/java/com/iexec/core/task/TaskServiceTests.java
+++ b/src/test/java/com/iexec/core/task/TaskServiceTests.java
@@ -268,7 +268,7 @@ public class TaskServiceTests {
         taskService.consensusReached2Reopened(task);
 
         assertThat(task.getLastButOneStatus()).isEqualTo(REOPEN_FAILED);
-        assertThat(task.getCurrentStatus()).isEqualTo(ERROR);
+        assertThat(task.getCurrentStatus()).isEqualTo(FAILED);
     }
 
     @Test
@@ -358,7 +358,7 @@ public class TaskServiceTests {
         taskService.tryUpgradeTaskStatus(task.getChainTaskId());
 
         assertThat(task.getLastButOneStatus()).isEqualTo(INITIALIZE_FAILED);
-        assertThat(task.getCurrentStatus()).isEqualTo(ERROR);
+        assertThat(task.getCurrentStatus()).isEqualTo(FAILED);
     }
 
     @Test
@@ -749,7 +749,7 @@ public class TaskServiceTests {
         TaskStatus lastButTwoStatus = task.getDateStatusList().get(task.getDateStatusList().size() - 3).getStatus();
         TaskStatus lastButThreeStatus = task.getDateStatusList().get(task.getDateStatusList().size() - 4).getStatus();
 
-        assertThat(task.getCurrentStatus()).isEqualTo(ERROR);
+        assertThat(task.getCurrentStatus()).isEqualTo(FAILED);
         assertThat(task.getLastButOneStatus()).isEqualTo(FINALIZE_FAILED);        
         assertThat(lastButTwoStatus).isEqualTo(FINALIZING);
         assertThat(lastButThreeStatus).isEqualTo(RESULT_UPLOADED);

--- a/src/test/java/com/iexec/core/task/TaskServiceTests.java
+++ b/src/test/java/com/iexec/core/task/TaskServiceTests.java
@@ -5,6 +5,7 @@ import com.iexec.common.replicate.ReplicateStatus;
 import com.iexec.common.replicate.ReplicateStatusModifier;
 import com.iexec.common.utils.BytesUtils;
 import com.iexec.core.chain.IexecHubService;
+import com.iexec.core.configuration.ResultRepositoryConfiguration;
 import com.iexec.core.replicate.Replicate;
 import com.iexec.core.replicate.ReplicatesService;
 import com.iexec.core.utils.DateTimeUtils;
@@ -55,6 +56,9 @@ public class TaskServiceTests {
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private ResultRepositoryConfiguration resulRepositoryConfig;
 
     @InjectMocks
     private TaskService taskService;
@@ -263,7 +267,8 @@ public class TaskServiceTests {
 
         taskService.consensusReached2Reopened(task);
 
-        assertThat(task.getCurrentStatus()).isEqualTo(REOPEN_FAILED);
+        assertThat(task.getLastButOneStatus()).isEqualTo(REOPEN_FAILED);
+        assertThat(task.getCurrentStatus()).isEqualTo(ERROR);
     }
 
     @Test
@@ -351,7 +356,9 @@ public class TaskServiceTests {
         when(iexecHubService.initialize(CHAIN_DEAL_ID, 1)).thenReturn(Optional.of(pair));
 
         taskService.tryUpgradeTaskStatus(task.getChainTaskId());
-        assertThat(task.getCurrentStatus()).isEqualTo(INITIALIZE_FAILED);
+
+        assertThat(task.getLastButOneStatus()).isEqualTo(INITIALIZE_FAILED);
+        assertThat(task.getCurrentStatus()).isEqualTo(ERROR);
     }
 
     @Test
@@ -693,6 +700,7 @@ public class TaskServiceTests {
         when(iexecHubService.getChainTask(any())).thenReturn(Optional.of(chainTask));
         when(iexecHubService.hasEnoughGas()).thenReturn(true);
         when(iexecHubService.finalizeTask(any(), any())).thenReturn(Optional.of(new ChainReceipt()));
+        when(resulRepositoryConfig.getResultRepositoryURL()).thenReturn("http://foo:bar");
 
         taskService.tryUpgradeTaskStatus(task.getChainTaskId());
 
@@ -738,12 +746,13 @@ public class TaskServiceTests {
 
         taskService.tryUpgradeTaskStatus(task.getChainTaskId());
 
-        TaskStatus lastButOneStatus = task.getDateStatusList().get(task.getDateStatusList().size() - 2).getStatus();
         TaskStatus lastButTwoStatus = task.getDateStatusList().get(task.getDateStatusList().size() - 3).getStatus();
+        TaskStatus lastButThreeStatus = task.getDateStatusList().get(task.getDateStatusList().size() - 4).getStatus();
 
-        assertThat(task.getCurrentStatus()).isEqualTo(FINALIZE_FAILED);
-        assertThat(lastButOneStatus).isEqualTo(FINALIZING);
-        assertThat(lastButTwoStatus).isEqualTo(RESULT_UPLOADED);
+        assertThat(task.getCurrentStatus()).isEqualTo(ERROR);
+        assertThat(task.getLastButOneStatus()).isEqualTo(FINALIZE_FAILED);        
+        assertThat(lastButTwoStatus).isEqualTo(FINALIZING);
+        assertThat(lastButThreeStatus).isEqualTo(RESULT_UPLOADED);
     }
 
 

--- a/src/test/java/com/iexec/core/task/TaskServiceTests.java
+++ b/src/test/java/com/iexec/core/task/TaskServiceTests.java
@@ -533,7 +533,8 @@ public class TaskServiceTests {
 
         taskService.tryUpgradeTaskStatus(CHAIN_TASK_ID);
 
-        assertThat(task.getCurrentStatus()).isEqualTo(CONTRIBUTION_TIMEOUT);
+        assertThat(task.getCurrentStatus()).isEqualTo(FAILED);
+        assertThat(task.getLastButOneStatus()).isEqualTo(CONTRIBUTION_TIMEOUT);
     }
 
 


### PR DESCRIPTION
- Update all failed tasks to ERROR status.
- Get tasks in non-final statuses (ERROR, COMPLETED).