### PR TITLE
Refactoring signatures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 iexecCommonVersion=3.0.0-SNAPSHOT
 packageCloudPassword=fake
 version=3.0.0-SNAPSHOT
+

--- a/src/main/java/com/iexec/core/chain/SignatureService.java
+++ b/src/main/java/com/iexec/core/chain/SignatureService.java
@@ -50,7 +50,7 @@ public class SignatureService {
                 .workerWallet(workerWallet)
                 .chainTaskId(chainTaskId)
                 .enclave(enclaveAddress)
-                .signature(new Signature(workerWallet, sign))
+                .signature(new Signature(sign))
                 .build();
     }
 

--- a/src/main/java/com/iexec/core/chain/SignatureService.java
+++ b/src/main/java/com/iexec/core/chain/SignatureService.java
@@ -1,8 +1,8 @@
 package com.iexec.core.chain;
 
 import com.iexec.common.chain.ContributionAuthorization;
+import com.iexec.common.security.Signature;
 import com.iexec.common.utils.BytesUtils;
-import com.iexec.common.utils.SignatureUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.Arrays;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,9 +50,7 @@ public class SignatureService {
                 .workerWallet(workerWallet)
                 .chainTaskId(chainTaskId)
                 .enclave(enclaveAddress)
-                .signR(sign.getR())
-                .signS(sign.getS())
-                .signV(sign.getV())
+                .signature(new Signature(workerWallet, sign))
                 .build();
     }
 

--- a/src/main/java/com/iexec/core/result/AuthorizationService.java
+++ b/src/main/java/com/iexec/core/result/AuthorizationService.java
@@ -24,9 +24,9 @@ public class AuthorizationService {
             return false;
         }
 
-        String eip712ChallengeString=authorization.getChallenge();
-        String challengeSignature=authorization.getChallengeSignature();
-        String walletAddress=authorization.getWalletAddress();
+        String eip712ChallengeString = authorization.getChallenge();
+        String challengeSignature = authorization.getChallengeSignature();
+        String walletAddress = authorization.getWalletAddress();
 
         challengeSignature = Numeric.cleanHexPrefix(challengeSignature);
 
@@ -37,7 +37,7 @@ public class AuthorizationService {
         String r = challengeSignature.substring(0, 64);
         String s = challengeSignature.substring(64, 128);
         String v = challengeSignature.substring(128, 130);
-        
+
         //ONE: check if eip712Challenge is in eip712Challenge map
         if (!challengeService.containsEip712ChallengeString(eip712ChallengeString)) {
             log.error("Eip712ChallengeString provided doesn't match any challenge [downloadRequester:{}]", walletAddress);

--- a/src/main/java/com/iexec/core/worker/WorkerController.java
+++ b/src/main/java/com/iexec/core/worker/WorkerController.java
@@ -85,7 +85,7 @@ public class WorkerController {
         String challenge = challengeService.getChallenge(walletAddress);
         byte[] hashTocheck = Hash.sha3(BytesUtils.stringToBytes(challenge));
 
-        if (SignatureUtils.doesSignatureMatchesAddress(signature.getSignR(), signature.getSignS(),
+        if (SignatureUtils.doesSignatureMatchesAddress(signature.getR(), signature.getS(),
                 BytesUtils.bytesToString(hashTocheck), walletAddress)) {
             String token = jwtTokenProvider.createToken(walletAddress);
             return ok(token);

--- a/src/test/java/com/iexec/core/chain/SignatureServiceTests.java
+++ b/src/test/java/com/iexec/core/chain/SignatureServiceTests.java
@@ -1,6 +1,7 @@
 package com.iexec.core.chain;
 
 import com.iexec.common.chain.ContributionAuthorization;
+import com.iexec.common.security.Signature;
 import com.iexec.common.utils.BytesUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,9 +57,10 @@ public class SignatureServiceTests {
                 .workerWallet(workerWallet)
                 .chainTaskId(chainTaskid)
                 .enclave(enclaveWallet)
-                .signR(BytesUtils.stringToBytes("0x63f2c959ed7dfc11619e1e0b5ba8a4bf56f81ce81d0b6e6e9cdeca538cb85d97"))
-                .signS(BytesUtils.stringToBytes("0x737747b747bc6c7d42cba859fdd030b1bed8b2513699ba78ac67dab5b785fda5"))
-                .signV((byte)28)
+                .signature(new Signature(workerWallet,
+                        BytesUtils.stringToBytes("0x63f2c959ed7dfc11619e1e0b5ba8a4bf56f81ce81d0b6e6e9cdeca538cb85d97"),
+                        BytesUtils.stringToBytes("0x737747b747bc6c7d42cba859fdd030b1bed8b2513699ba78ac67dab5b785fda5"),
+                        (byte)28))
                 .build();
 
         assertEquals(auth, expected);

--- a/src/test/java/com/iexec/core/chain/SignatureServiceTests.java
+++ b/src/test/java/com/iexec/core/chain/SignatureServiceTests.java
@@ -57,7 +57,7 @@ public class SignatureServiceTests {
                 .workerWallet(workerWallet)
                 .chainTaskId(chainTaskid)
                 .enclave(enclaveWallet)
-                .signature(new Signature(workerWallet,
+                .signature(new Signature(
                         BytesUtils.stringToBytes("0x63f2c959ed7dfc11619e1e0b5ba8a4bf56f81ce81d0b6e6e9cdeca538cb85d97"),
                         BytesUtils.stringToBytes("0x737747b747bc6c7d42cba859fdd030b1bed8b2513699ba78ac67dab5b785fda5"),
                         (byte)28))


### PR DESCRIPTION
Signatures are used in different places in the code, a few structures were redefining the same fields over and over again:
- Signature
- ContributionAutorization
- TeeSignature

Now there is only one class (Signature) handling a string (like the SDK and the PoCo do).
