### PR TITLE
Feature/exclude junit4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,10 @@ dependencies {
     testImplementation 'org.awaitility:awaitility:4.0.1'
 }
 
+test {
+    useJUnitPlatform()
+}
+
 jacoco {
     toolVersion = "0.8.3"
 }

--- a/src/test/java/com/iexec/core/chain/DealWatcherServiceTests.java
+++ b/src/test/java/com/iexec/core/chain/DealWatcherServiceTests.java
@@ -25,8 +25,8 @@ import com.iexec.core.task.Task;
 import com.iexec.core.task.TaskService;
 import com.iexec.core.task.event.TaskCreatedEvent;
 import io.reactivex.Flowable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -54,7 +54,7 @@ public class DealWatcherServiceTests {
     @InjectMocks
     private DealWatcherService dealWatcherService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/chain/DealWatcherServiceTests.java
+++ b/src/test/java/com/iexec/core/chain/DealWatcherServiceTests.java
@@ -33,7 +33,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/com/iexec/core/chain/SignatureServiceTests.java
+++ b/src/test/java/com/iexec/core/chain/SignatureServiceTests.java
@@ -22,14 +22,14 @@ import com.iexec.common.utils.BytesUtils;
 import com.iexec.common.utils.HashUtils;
 import com.iexec.core.configuration.SmsConfiguration;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.web3j.crypto.Credentials;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 
@@ -41,7 +41,7 @@ public class SignatureServiceTests {
     @InjectMocks
     private SignatureService signatureService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }
@@ -55,7 +55,7 @@ public class SignatureServiceTests {
 
         String expected = "0x54a76d209e8167e1ffa3bde8e3e7b30068423ca9554e1d605d8ee8fd0f165562";
 
-        assertEquals(expected, HashUtils.concatenateAndHash(workerWallet, chainTaskid, enclaveWallet));
+        Assertions.assertEquals(expected, HashUtils.concatenateAndHash(workerWallet, chainTaskid, enclaveWallet));
     }
 
     @Test
@@ -82,7 +82,7 @@ public class SignatureServiceTests {
                         new byte[]{(byte)28}))
                 .build();
 
-        assertEquals(authorization, expected);
+        Assertions.assertEquals(authorization, expected);
 
     }
 }

--- a/src/test/java/com/iexec/core/chain/adapter/BlockchainAdapterServiceTests.java
+++ b/src/test/java/com/iexec/core/chain/adapter/BlockchainAdapterServiceTests.java
@@ -19,8 +19,8 @@ package com.iexec.core.chain.adapter;
 import com.iexec.common.chain.adapter.CommandStatus;
 import com.iexec.common.chain.adapter.args.TaskFinalizeArgs;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -47,7 +47,7 @@ public class BlockchainAdapterServiceTests {
     @InjectMocks
     private BlockchainAdapterService blockchainAdapterService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/configuration/ConfigurationRepositoryMigrationTest.java
+++ b/src/test/java/com/iexec/core/configuration/ConfigurationRepositoryMigrationTest.java
@@ -21,8 +21,8 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -39,7 +39,7 @@ public class ConfigurationRepositoryMigrationTest {
     @Mock
     private ReplayConfigurationRepository replayConfigurationRepository;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/configuration/ConfigurationServiceTests.java
+++ b/src/test/java/com/iexec/core/configuration/ConfigurationServiceTests.java
@@ -17,8 +17,8 @@
 package com.iexec.core.configuration;
 
 import com.iexec.core.chain.ChainConfig;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -44,7 +44,7 @@ public class ConfigurationServiceTests {
     @InjectMocks
     private ConfigurationService configurationService;
 
-    @Before
+    @BeforeEach
     public void init() { MockitoAnnotations.initMocks(this); }
 
     @Test

--- a/src/test/java/com/iexec/core/configuration/ConfigurationServiceTests.java
+++ b/src/test/java/com/iexec/core/configuration/ConfigurationServiceTests.java
@@ -23,7 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/iexec/core/contribution/ConsensusServiceTests.java
+++ b/src/test/java/com/iexec/core/contribution/ConsensusServiceTests.java
@@ -16,8 +16,8 @@
 
 package com.iexec.core.contribution;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -43,7 +43,7 @@ public class ConsensusServiceTests {
     @InjectMocks
     private ConsensusService consensusService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/contribution/ConsensusServiceTests.java
+++ b/src/test/java/com/iexec/core/contribution/ConsensusServiceTests.java
@@ -22,7 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 

--- a/src/test/java/com/iexec/core/contribution/ContributionServiceTests.java
+++ b/src/test/java/com/iexec/core/contribution/ContributionServiceTests.java
@@ -19,8 +19,8 @@ package com.iexec.core.contribution;
 import com.iexec.common.replicate.ReplicateStatus;
 import com.iexec.core.replicate.Replicate;
 import com.iexec.core.replicate.ReplicatesService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -47,7 +47,7 @@ public class ContributionServiceTests {
     @InjectMocks
     private ContributionService contributionService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/contribution/ContributionServiceTests.java
+++ b/src/test/java/com/iexec/core/contribution/ContributionServiceTests.java
@@ -27,7 +27,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.*;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/com/iexec/core/contribution/PredictionServiceTests.java
+++ b/src/test/java/com/iexec/core/contribution/PredictionServiceTests.java
@@ -16,8 +16,8 @@
 
 package com.iexec.core.contribution;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -42,7 +42,7 @@ public class PredictionServiceTests {
     @InjectMocks
     private PredictionService predictionService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/contribution/PredictionServiceTests.java
+++ b/src/test/java/com/iexec/core/contribution/PredictionServiceTests.java
@@ -27,7 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 

--- a/src/test/java/com/iexec/core/detector/WorkerLostDetectorTests.java
+++ b/src/test/java/com/iexec/core/detector/WorkerLostDetectorTests.java
@@ -24,8 +24,8 @@ import com.iexec.core.replicate.ReplicatesService;
 import com.iexec.core.task.TaskService;
 import com.iexec.core.worker.Worker;
 import com.iexec.core.worker.WorkerService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -56,7 +56,7 @@ public class WorkerLostDetectorTests {
     @InjectMocks
     private WorkerLostDetector workerLostDetector;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/detector/replicate/ContributionUnnotifiedDetectorTests.java
+++ b/src/test/java/com/iexec/core/detector/replicate/ContributionUnnotifiedDetectorTests.java
@@ -27,8 +27,8 @@ import com.iexec.core.replicate.ReplicatesService;
 import com.iexec.core.task.Task;
 import com.iexec.core.task.TaskService;
 import com.iexec.core.task.TaskStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 import java.util.Arrays;
@@ -64,7 +64,7 @@ public class ContributionUnnotifiedDetectorTests {
     @InjectMocks
     private ContributionUnnotifiedDetector contributionDetector;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/detector/replicate/ReplicateResultUploadTimeoutDetectorTests.java
+++ b/src/test/java/com/iexec/core/detector/replicate/ReplicateResultUploadTimeoutDetectorTests.java
@@ -21,8 +21,8 @@ import com.iexec.common.replicate.ReplicateStatusModifier;
 import com.iexec.core.replicate.Replicate;
 import com.iexec.core.replicate.ReplicatesService;
 import com.iexec.core.task.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -55,7 +55,7 @@ public class ReplicateResultUploadTimeoutDetectorTests {
     @InjectMocks
     private ReplicateResultUploadTimeoutDetector timeoutDetector;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/detector/replicate/RevealTimeoutDetectorTests.java
+++ b/src/test/java/com/iexec/core/detector/replicate/RevealTimeoutDetectorTests.java
@@ -25,8 +25,8 @@ import com.iexec.core.replicate.ReplicatesService;
 import com.iexec.core.task.Task;
 import com.iexec.core.task.TaskService;
 import com.iexec.core.task.TaskStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -59,7 +59,7 @@ public class RevealTimeoutDetectorTests {
     @InjectMocks
     private RevealTimeoutDetector revealDetector;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/detector/replicate/RevealUnnotifiedDetectorTests.java
+++ b/src/test/java/com/iexec/core/detector/replicate/RevealUnnotifiedDetectorTests.java
@@ -27,8 +27,8 @@ import com.iexec.core.replicate.ReplicatesService;
 import com.iexec.core.task.Task;
 import com.iexec.core.task.TaskService;
 import com.iexec.core.task.TaskStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 import java.util.Collections;
@@ -63,7 +63,7 @@ public class RevealUnnotifiedDetectorTests {
     @InjectMocks
     private RevealUnnotifiedDetector revealDetector;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/detector/task/ContributionTimeoutTaskDetectorTests.java
+++ b/src/test/java/com/iexec/core/detector/task/ContributionTimeoutTaskDetectorTests.java
@@ -24,8 +24,8 @@ import com.iexec.core.task.TaskStatus;
 import com.iexec.common.utils.DateTimeUtils;
 import com.iexec.core.task.TaskUpdateManager;
 import com.iexec.core.worker.WorkerService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 import java.util.Arrays;
@@ -55,7 +55,7 @@ public class ContributionTimeoutTaskDetectorTests {
     @InjectMocks
     private ContributionTimeoutTaskDetector contributionDetector;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/detector/task/FinalDeadlineTaskDetectorTests.java
+++ b/src/test/java/com/iexec/core/detector/task/FinalDeadlineTaskDetectorTests.java
@@ -20,8 +20,8 @@ import com.iexec.core.task.Task;
 import com.iexec.core.task.TaskService;
 import com.iexec.core.task.TaskStatus;
 import com.iexec.core.task.TaskUpdateManager;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -49,7 +49,7 @@ public class FinalDeadlineTaskDetectorTests {
     @InjectMocks
     private FinalDeadlineTaskDetector finalDeadlineTaskDetector;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/detector/task/TaskResultUploadTimeoutDetectorTests.java
+++ b/src/test/java/com/iexec/core/detector/task/TaskResultUploadTimeoutDetectorTests.java
@@ -22,8 +22,8 @@ import com.iexec.core.task.TaskStatus;
 import com.iexec.common.utils.DateTimeUtils;
 
 import com.iexec.core.task.TaskUpdateManager;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -31,10 +31,8 @@ import org.mockito.MockitoAnnotations;
 
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 
 public class TaskResultUploadTimeoutDetectorTests {
 
@@ -47,7 +45,7 @@ public class TaskResultUploadTimeoutDetectorTests {
     @InjectMocks
     private TaskResultUploadTimeoutDetector taskResultUploadTimeoutDetector;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/detector/task/UnstartedTxDetectorTests.java
+++ b/src/test/java/com/iexec/core/detector/task/UnstartedTxDetectorTests.java
@@ -19,8 +19,8 @@ package com.iexec.core.detector.task;
 import com.iexec.core.task.Task;
 import com.iexec.core.task.TaskService;
 import com.iexec.core.task.TaskUpdateManager;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -42,7 +42,7 @@ public class UnstartedTxDetectorTests {
     @InjectMocks
     private UnstartedTxDetector unstartedTxDetector;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/metric/MetricControllerTests.java
+++ b/src/test/java/com/iexec/core/metric/MetricControllerTests.java
@@ -17,8 +17,8 @@
 package com.iexec.core.metric;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -34,7 +34,7 @@ public class MetricControllerTests {
     @InjectMocks
     private MetricController metricController;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/metric/MetricServiceTests.java
+++ b/src/test/java/com/iexec/core/metric/MetricServiceTests.java
@@ -20,8 +20,8 @@ import com.iexec.core.task.TaskService;
 import com.iexec.core.task.TaskStatus;
 import com.iexec.core.worker.Worker;
 import com.iexec.core.worker.WorkerService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -41,7 +41,7 @@ public class MetricServiceTests {
     @InjectMocks
     private MetricService metricService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/pubsub/NotificationServiceTests.java
+++ b/src/test/java/com/iexec/core/pubsub/NotificationServiceTests.java
@@ -16,8 +16,8 @@
 
 package com.iexec.core.pubsub;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -36,7 +36,7 @@ public class NotificationServiceTests {
     @InjectMocks
     private NotificationService notificationService;
 
-    @Before
+    @BeforeEach
     public void init() { MockitoAnnotations.initMocks(this); }
 
     @Test

--- a/src/test/java/com/iexec/core/replicate/ReplicateControllerTests.java
+++ b/src/test/java/com/iexec/core/replicate/ReplicateControllerTests.java
@@ -8,8 +8,8 @@ import com.iexec.common.replicate.ReplicateStatusModifier;
 import com.iexec.common.replicate.ReplicateStatusUpdate;
 import com.iexec.core.security.JwtTokenProvider;
 import com.iexec.core.worker.WorkerService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -51,7 +51,7 @@ public class ReplicateControllerTests {
     @InjectMocks
     private ReplicatesController replicatesController;
 
-    @Before
+    @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/replicate/ReplicateListenersTests.java
+++ b/src/test/java/com/iexec/core/replicate/ReplicateListenersTests.java
@@ -23,8 +23,8 @@ import com.iexec.core.task.TaskService;
 import com.iexec.core.task.TaskUpdateManager;
 import com.iexec.core.task.listener.ReplicateListeners;
 import com.iexec.core.worker.WorkerService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -56,7 +56,7 @@ public class ReplicateListenersTests {
     private ReplicateListeners replicateListeners;
 
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/replicate/ReplicateServiceTests.java
+++ b/src/test/java/com/iexec/core/replicate/ReplicateServiceTests.java
@@ -30,8 +30,8 @@ import com.iexec.core.chain.Web3jService;
 import com.iexec.core.result.ResultService;
 import com.iexec.core.stdout.StdoutService;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -72,7 +72,7 @@ public class ReplicateServiceTests {
     @InjectMocks
     private ReplicatesService replicatesService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/replicate/ReplicateSupplyServiceTests.java
+++ b/src/test/java/com/iexec/core/replicate/ReplicateSupplyServiceTests.java
@@ -38,8 +38,8 @@ import com.iexec.common.utils.DateTimeUtils;
 import com.iexec.core.task.TaskUpdateManager;
 import com.iexec.core.worker.Worker;
 import com.iexec.core.worker.WorkerService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -83,7 +83,7 @@ public class ReplicateSupplyServiceTests {
     @InjectMocks
     private ReplicateSupplyService replicateSupplyService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/replicate/ReplicateTests.java
+++ b/src/test/java/com/iexec/core/replicate/ReplicateTests.java
@@ -20,7 +20,7 @@ import com.iexec.common.replicate.ReplicateStatus;
 import com.iexec.common.replicate.ReplicateStatusModifier;
 import com.iexec.common.replicate.ReplicateStatusUpdate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Date;

--- a/src/test/java/com/iexec/core/security/ChallengeServiceTests.java
+++ b/src/test/java/com/iexec/core/security/ChallengeServiceTests.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChallengeServiceTests {
 

--- a/src/test/java/com/iexec/core/security/ChallengeServiceTests.java
+++ b/src/test/java/com/iexec/core/security/ChallengeServiceTests.java
@@ -16,8 +16,8 @@
 
 package com.iexec.core.security;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -29,7 +29,7 @@ public class ChallengeServiceTests {
 
     private ChallengeService challengeService = new ChallengeService();
 
-    @Before
+    @BeforeEach
     public void init() { MockitoAnnotations.initMocks(this); }
 
     @Test

--- a/src/test/java/com/iexec/core/security/JwtTokenProviderTests.java
+++ b/src/test/java/com/iexec/core/security/JwtTokenProviderTests.java
@@ -25,7 +25,7 @@ import org.mockito.MockitoAnnotations;
 
 import io.jsonwebtoken.MalformedJwtException;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 public class JwtTokenProviderTests {

--- a/src/test/java/com/iexec/core/security/JwtTokenProviderTests.java
+++ b/src/test/java/com/iexec/core/security/JwtTokenProviderTests.java
@@ -16,8 +16,9 @@
 
 package com.iexec.core.security;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -37,7 +38,7 @@ public class JwtTokenProviderTests {
     @InjectMocks
     private JwtTokenProvider jwtTokenProvider;
 
-    @Before
+    @BeforeEach
     public void init() { MockitoAnnotations.initMocks(this); }
 
     @Test
@@ -114,10 +115,10 @@ public class JwtTokenProviderTests {
         assertThat(walletAddress).isEqualTo(WALLET_WORKER);
     }
 
-    @Test(expected=MalformedJwtException.class)
+    @Test
     public void shouldThrowJwtExceptionSinceNotValidToken() {
         jwtTokenProvider.init();
-        jwtTokenProvider.getWalletAddress("non.valid.token");
+        Assertions.assertThrows(MalformedJwtException.class, () -> jwtTokenProvider.getWalletAddress("non.valid.token"));
     }
 
     @Test

--- a/src/test/java/com/iexec/core/sms/SmsServiceTests.java
+++ b/src/test/java/com/iexec/core/sms/SmsServiceTests.java
@@ -3,8 +3,8 @@ package com.iexec.core.sms;
 import com.iexec.common.utils.BytesUtils;
 import com.iexec.core.feign.SmsClient;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -21,7 +21,7 @@ public class SmsServiceTests {
     @InjectMocks
     private SmsService smsService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/stdout/StdoutCronServiceTests.java
+++ b/src/test/java/com/iexec/core/stdout/StdoutCronServiceTests.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 import com.iexec.core.task.TaskService;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -25,7 +25,7 @@ public class StdoutCronServiceTests {
     @InjectMocks
     private StdoutCronService stdoutCronService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/stdout/TaskStdoutServiceTests.java
+++ b/src/test/java/com/iexec/core/stdout/TaskStdoutServiceTests.java
@@ -28,8 +28,8 @@ import java.util.Optional;
 
 import com.iexec.core.task.TaskService;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -46,7 +46,7 @@ public class TaskStdoutServiceTests {
     @InjectMocks
     private StdoutService stdoutService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/task/TaskServiceTests.java
+++ b/src/test/java/com/iexec/core/task/TaskServiceTests.java
@@ -18,8 +18,8 @@ package com.iexec.core.task;
 
 import com.iexec.core.task.update.TaskUpdateRequestManager;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -51,13 +51,13 @@ public class TaskServiceTests {
     @InjectMocks
     private TaskService taskService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }
 
     @Test
-    public void shouldNotgetTaskWithTrust() {
+    public void shouldNotGetTaskWithTrust() {
         when(taskRepository.findByChainTaskId("dummyId")).thenReturn(Optional.empty());
         Optional<Task> task = taskService.getTaskByChainTaskId("dummyId");
         assertThat(task.isPresent()).isFalse();

--- a/src/test/java/com/iexec/core/task/TaskTests.java
+++ b/src/test/java/com/iexec/core/task/TaskTests.java
@@ -18,7 +18,7 @@ package com.iexec.core.task;
 
 
 import com.iexec.common.utils.DateTimeUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Date;

--- a/src/test/java/com/iexec/core/task/TaskUpdateManagerTest.java
+++ b/src/test/java/com/iexec/core/task/TaskUpdateManagerTest.java
@@ -33,8 +33,8 @@ import com.iexec.core.task.event.PleaseUploadEvent;
 import com.iexec.core.task.update.TaskUpdateRequestManager;
 import com.iexec.core.worker.Worker;
 import com.iexec.core.worker.WorkerService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -95,7 +95,7 @@ public class TaskUpdateManagerTest {
     @InjectMocks
     private TaskUpdateManager taskUpdateManager;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/task/listener/TaskListenerTest.java
+++ b/src/test/java/com/iexec/core/task/listener/TaskListenerTest.java
@@ -26,8 +26,8 @@ import com.iexec.core.task.Task;
 import com.iexec.core.task.TaskUpdateManager;
 import com.iexec.core.task.event.*;
 import com.iexec.core.worker.WorkerService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 import java.util.Collections;
@@ -58,7 +58,7 @@ public class TaskListenerTest {
     @InjectMocks
     private TaskListeners taskListeners;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/task/update/TaskUpdateRequestManagerTests.java
+++ b/src/test/java/com/iexec/core/task/update/TaskUpdateRequestManagerTests.java
@@ -2,8 +2,8 @@ package com.iexec.core.task.update;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 
@@ -18,7 +18,7 @@ public class TaskUpdateRequestManagerTests {
     @InjectMocks
     private TaskUpdateRequestManager taskUpdateRequestManager;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/worker/WorkerControllerTests.java
+++ b/src/test/java/com/iexec/core/worker/WorkerControllerTests.java
@@ -10,8 +10,8 @@ import com.iexec.core.configuration.SmsConfiguration;
 import com.iexec.core.configuration.WorkerConfiguration;
 import com.iexec.core.security.ChallengeService;
 import com.iexec.core.security.JwtTokenProvider;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -61,7 +61,7 @@ public class WorkerControllerTests {
     @InjectMocks
     private WorkerController workerController;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/worker/WorkerServiceTests.java
+++ b/src/test/java/com/iexec/core/worker/WorkerServiceTests.java
@@ -17,8 +17,8 @@
 package com.iexec.core.worker;
 
 import com.iexec.core.configuration.WorkerConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 import java.text.ParseException;
@@ -42,7 +42,7 @@ public class WorkerServiceTests {
     @InjectMocks
     private WorkerService workerService;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/com/iexec/core/workflow/ReplicateWorkflowTests.java
+++ b/src/test/java/com/iexec/core/workflow/ReplicateWorkflowTests.java
@@ -19,9 +19,8 @@ package com.iexec.core.workflow;
 import com.iexec.common.notification.TaskNotificationType;
 import com.iexec.common.replicate.ReplicateStatus;
 import com.iexec.common.replicate.ReplicateStatusCause;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.MockitoAnnotations;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +28,7 @@ public class ReplicateWorkflowTests {
 
     private ReplicateWorkflow replicateWorkflow;
 
-    @Before
+    @BeforeEach
     public void setup() {
         replicateWorkflow = ReplicateWorkflow.getInstance();
     }

--- a/src/test/java/com/iexec/core/workflow/WorkflowTests.java
+++ b/src/test/java/com/iexec/core/workflow/WorkflowTests.java
@@ -16,7 +16,7 @@
 
 package com.iexec.core.workflow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/iexec/core/workflow/WorkflowToJson.java
+++ b/src/test/java/com/iexec/core/workflow/WorkflowToJson.java
@@ -16,7 +16,7 @@
 
 package com.iexec.core.workflow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WorkflowToJson {
 


### PR DESCRIPTION
Tests updated
`grep -r org.junit src | grep -v jupiter` returns an empty set
(no code uses an org.junit package which does not belong to jupiter, ie junit 5)