### PR TITLE
Fix `initialized2Running`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=6.4.1
+version=6.4.2
 iexecCommonVersion=5.8.0
 nexusUser=fake
 nexusPassword=fake

--- a/src/main/java/com/iexec/core/replicate/ReplicatesService.java
+++ b/src/main/java/com/iexec/core/replicate/ReplicatesService.java
@@ -141,6 +141,18 @@ public class ReplicatesService {
         return nbReplicates;
     }
 
+    public int getNbReplicatesWithLastRelevantStatus(String chainTaskId, ReplicateStatus... listStatus) {
+        int nbReplicates = 0;
+        for (Replicate replicate : getReplicates(chainTaskId)) {
+            for (ReplicateStatus status : listStatus) {
+                if (Objects.equals(replicate.getLastRelevantStatus().orElse(null), status)) {
+                    nbReplicates++;
+                }
+            }
+        }
+        return nbReplicates;
+    }
+
     public int getNbReplicatesContainingStatus(String chainTaskId, ReplicateStatus... listStatus) {
         Set<String> addressReplicates = new HashSet<>();
         for (Replicate replicate : getReplicates(chainTaskId)) {

--- a/src/main/java/com/iexec/core/task/TaskUpdateManager.java
+++ b/src/main/java/com/iexec/core/task/TaskUpdateManager.java
@@ -254,8 +254,7 @@ public class TaskUpdateManager implements TaskUpdateRequestConsumer  {
 
         // We explicitly exclude START_FAILED as it could denote some serious issues
         // The task should not transition to `RUNNING` in this case.
-        final int nbReplicatesContainingStartingStatus = replicatesService.getNbReplicatesWithCurrentStatus(
-                chainTaskId,
+        final ReplicateStatus[] acceptableStatus = new ReplicateStatus[]{
                 ReplicateStatus.STARTED,
                 ReplicateStatus.APP_DOWNLOADING,
                 ReplicateStatus.APP_DOWNLOAD_FAILED,
@@ -269,7 +268,8 @@ public class TaskUpdateManager implements TaskUpdateRequestConsumer  {
                 ReplicateStatus.CONTRIBUTING,
                 ReplicateStatus.CONTRIBUTE_FAILED,
                 ReplicateStatus.CONTRIBUTED
-        );
+        };
+        final int nbReplicatesContainingStartingStatus = replicatesService.getNbReplicatesWithLastRelevantStatus(chainTaskId, acceptableStatus);
         boolean condition1 = nbReplicatesContainingStartingStatus > 0;
         boolean condition2 = task.getCurrentStatus().equals(INITIALIZED);
 

--- a/src/main/java/com/iexec/core/task/TaskUpdateManager.java
+++ b/src/main/java/com/iexec/core/task/TaskUpdateManager.java
@@ -251,7 +251,18 @@ public class TaskUpdateManager implements TaskUpdateRequestConsumer  {
 
     void initialized2Running(Task task) {
         String chainTaskId = task.getChainTaskId();
-        boolean condition1 = replicatesService.getNbReplicatesWithCurrentStatus(chainTaskId, ReplicateStatus.STARTING, ReplicateStatus.COMPUTED) > 0;
+        boolean condition1 = replicatesService.getNbReplicatesWithCurrentStatus(
+                chainTaskId,
+                ReplicateStatus.STARTING,
+                ReplicateStatus.STARTED,
+                ReplicateStatus.APP_DOWNLOADING,
+                ReplicateStatus.APP_DOWNLOADED,
+                ReplicateStatus.DATA_DOWNLOADING,
+                ReplicateStatus.DATA_DOWNLOADED,
+                ReplicateStatus.COMPUTING,
+                ReplicateStatus.COMPUTED,
+                ReplicateStatus.CONTRIBUTING,
+                ReplicateStatus.CONTRIBUTED) > 0;
         boolean condition2 = task.getCurrentStatus().equals(INITIALIZED);
 
         if (condition1 && condition2) {

--- a/src/test/java/com/iexec/core/replicate/ReplicateServiceTests.java
+++ b/src/test/java/com/iexec/core/replicate/ReplicateServiceTests.java
@@ -260,6 +260,61 @@ public class ReplicateServiceTests {
     }
 
     @Test
+    public void shouldGetCorrectNbReplicatesWithOneLastRelevantStatus() {
+        Replicate replicate1 = new Replicate(WALLET_WORKER_1, CHAIN_TASK_ID);
+        replicate1.updateStatus(STARTING, ReplicateStatusModifier.WORKER);
+        replicate1.updateStatus(COMPUTED, ReplicateStatusModifier.WORKER);
+        Replicate replicate2 = new Replicate(WALLET_WORKER_2, CHAIN_TASK_ID);
+        replicate2.updateStatus(STARTING, ReplicateStatusModifier.WORKER);
+        Replicate replicate3 = new Replicate(WALLET_WORKER_3, CHAIN_TASK_ID);
+        replicate3.updateStatus(STARTING, ReplicateStatusModifier.WORKER);
+        Replicate replicate4 = new Replicate(WALLET_WORKER_4, CHAIN_TASK_ID);
+        replicate4.updateStatus(STARTING, ReplicateStatusModifier.WORKER);
+        replicate4.updateStatus(WORKER_LOST, ReplicateStatusModifier.WORKER);
+
+        ReplicatesList replicatesList = new ReplicatesList(CHAIN_TASK_ID, Arrays.asList(replicate1, replicate2, replicate3, replicate4));
+
+        when(replicatesRepository.findByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(replicatesList));
+
+        assertThat(replicatesService.getNbReplicatesWithLastRelevantStatus(CHAIN_TASK_ID, STARTING)).isEqualTo(3);
+        assertThat(replicatesService.getNbReplicatesWithLastRelevantStatus(CHAIN_TASK_ID, COMPUTED)).isEqualTo(1);
+        assertThat(replicatesService.getNbReplicatesWithLastRelevantStatus(CHAIN_TASK_ID, CONTRIBUTED)).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldGetCorrectNbReplicatesWithMultipleLastReleveantStatus() {
+        Replicate replicate1 = new Replicate(WALLET_WORKER_1, CHAIN_TASK_ID);
+        replicate1.updateStatus(STARTING, ReplicateStatusModifier.WORKER);
+        replicate1.updateStatus(COMPUTED, ReplicateStatusModifier.WORKER);
+        Replicate replicate2 = new Replicate(WALLET_WORKER_2, CHAIN_TASK_ID);
+        replicate2.updateStatus(STARTING, ReplicateStatusModifier.WORKER);
+        Replicate replicate3 = new Replicate(WALLET_WORKER_3, CHAIN_TASK_ID);
+        replicate3.updateStatus(STARTING, ReplicateStatusModifier.WORKER);
+        Replicate replicate4 = new Replicate(WALLET_WORKER_4, CHAIN_TASK_ID);
+        replicate4.updateStatus(STARTING, ReplicateStatusModifier.WORKER);
+        replicate4.updateStatus(COMPUTED, ReplicateStatusModifier.WORKER);
+        replicate4.updateStatus(CONTRIBUTED, ReplicateStatusModifier.WORKER);
+        Replicate replicate5 = new Replicate(WALLET_WORKER_4, CHAIN_TASK_ID);
+        replicate5.updateStatus(STARTING, ReplicateStatusModifier.WORKER);
+        replicate5.updateStatus(RECOVERING, ReplicateStatusModifier.WORKER);
+
+        ReplicatesList replicatesList = new ReplicatesList(CHAIN_TASK_ID, Arrays.asList(replicate1, replicate2, replicate3, replicate4, replicate5));
+
+        when(replicatesRepository.findByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(replicatesList));
+
+        int shouldBe2 = replicatesService.getNbReplicatesWithLastRelevantStatus(CHAIN_TASK_ID, COMPUTED, CONTRIBUTED);
+        assertThat(shouldBe2).isEqualTo(2);
+
+        int shouldBe3 = replicatesService.getNbReplicatesWithLastRelevantStatus(CHAIN_TASK_ID, STARTING, COMPUTED);
+        assertThat(shouldBe3).isEqualTo(4);
+
+        int shouldBe4 = replicatesService.getNbReplicatesWithLastRelevantStatus(CHAIN_TASK_ID, STARTING, COMPUTED,
+                CONTRIBUTED);
+        assertThat(shouldBe4).isEqualTo(5);
+
+    }
+
+    @Test
     public void shouldGetCorrectNbReplicatesContainingOneStatus() {
         Replicate replicate1 = new Replicate(WALLET_WORKER_1, CHAIN_TASK_ID);
         replicate1.updateStatus(STARTING, ReplicateStatusModifier.WORKER);

--- a/src/test/java/com/iexec/core/task/TaskUpdateManagerTest.java
+++ b/src/test/java/com/iexec/core/task/TaskUpdateManagerTest.java
@@ -409,7 +409,18 @@ public class TaskUpdateManagerTest {
         Task task = getStubTask(maxExecutionTime);
         task.changeStatus(INITIALIZED);
 
-        when(replicatesService.getNbReplicatesWithCurrentStatus(task.getChainTaskId(), ReplicateStatus.STARTING, ReplicateStatus.COMPUTED)).thenReturn(2);
+        when(replicatesService.getNbReplicatesWithCurrentStatus(
+                task.getChainTaskId(),
+                ReplicateStatus.STARTING,
+                ReplicateStatus.STARTED,
+                ReplicateStatus.APP_DOWNLOADING,
+                ReplicateStatus.APP_DOWNLOADED,
+                ReplicateStatus.DATA_DOWNLOADING,
+                ReplicateStatus.DATA_DOWNLOADED,
+                ReplicateStatus.COMPUTING,
+                ReplicateStatus.COMPUTED,
+                ReplicateStatus.CONTRIBUTING,
+                ReplicateStatus.CONTRIBUTED)).thenReturn(2);
         when(replicatesService.getNbReplicatesWithCurrentStatus(task.getChainTaskId(), ReplicateStatus.COMPUTED)).thenReturn(0);
         when(taskRepository.save(task)).thenReturn(task);
         when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
@@ -1422,7 +1433,18 @@ public class TaskUpdateManagerTest {
         task.changeStatus(INITIALIZED);
 
         when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
-        when(replicatesService.getNbReplicatesWithCurrentStatus(CHAIN_TASK_ID, ReplicateStatus.STARTING, ReplicateStatus.COMPUTED)).thenReturn(3);
+        when(replicatesService.getNbReplicatesWithCurrentStatus(
+                CHAIN_TASK_ID,
+                ReplicateStatus.STARTING,
+                ReplicateStatus.STARTED,
+                ReplicateStatus.APP_DOWNLOADING,
+                ReplicateStatus.APP_DOWNLOADED,
+                ReplicateStatus.DATA_DOWNLOADING,
+                ReplicateStatus.DATA_DOWNLOADED,
+                ReplicateStatus.COMPUTING,
+                ReplicateStatus.COMPUTED,
+                ReplicateStatus.CONTRIBUTING,
+                ReplicateStatus.CONTRIBUTED)).thenReturn(3);
         when(replicatesService.getNbReplicatesWithCurrentStatus(CHAIN_TASK_ID, ReplicateStatus.COMPUTED)).thenReturn(0);
 
         taskUpdateManager.updateTask(task.getChainTaskId());
@@ -1436,7 +1458,18 @@ public class TaskUpdateManagerTest {
         task.changeStatus(INITIALIZED);
 
         when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
-        when(replicatesService.getNbReplicatesWithCurrentStatus(CHAIN_TASK_ID, ReplicateStatus.STARTING, ReplicateStatus.COMPUTED)).thenReturn(4);
+        when(replicatesService.getNbReplicatesWithCurrentStatus(
+                CHAIN_TASK_ID,
+                ReplicateStatus.STARTING,
+                ReplicateStatus.STARTED,
+                ReplicateStatus.APP_DOWNLOADING,
+                ReplicateStatus.APP_DOWNLOADED,
+                ReplicateStatus.DATA_DOWNLOADING,
+                ReplicateStatus.DATA_DOWNLOADED,
+                ReplicateStatus.COMPUTING,
+                ReplicateStatus.COMPUTED,
+                ReplicateStatus.CONTRIBUTING,
+                ReplicateStatus.CONTRIBUTED)).thenReturn(4);
         when(replicatesService.getNbReplicatesWithCurrentStatus(CHAIN_TASK_ID, ReplicateStatus.COMPUTED)).thenReturn(2);
 
         taskUpdateManager.updateTask(task.getChainTaskId());

--- a/src/test/java/com/iexec/core/task/TaskUpdateManagerTest.java
+++ b/src/test/java/com/iexec/core/task/TaskUpdateManagerTest.java
@@ -409,8 +409,7 @@ public class TaskUpdateManagerTest {
         Task task = getStubTask(maxExecutionTime);
         task.changeStatus(INITIALIZED);
 
-        when(replicatesService.getNbReplicatesWithCurrentStatus(
-                task.getChainTaskId(),
+        final ReplicateStatus[] acceptableStatus = new ReplicateStatus[]{
                 ReplicateStatus.STARTED,
                 ReplicateStatus.APP_DOWNLOADING,
                 ReplicateStatus.APP_DOWNLOAD_FAILED,
@@ -423,7 +422,11 @@ public class TaskUpdateManagerTest {
                 ReplicateStatus.COMPUTED,
                 ReplicateStatus.CONTRIBUTING,
                 ReplicateStatus.CONTRIBUTE_FAILED,
-                ReplicateStatus.CONTRIBUTED)).thenReturn(2);
+                ReplicateStatus.CONTRIBUTED
+        };
+
+        when(replicatesService.getNbReplicatesWithLastRelevantStatus(task.getChainTaskId(), acceptableStatus))
+                .thenReturn(2);
         when(replicatesService.getNbReplicatesWithCurrentStatus(task.getChainTaskId(), ReplicateStatus.COMPUTED)).thenReturn(0);
         when(taskRepository.save(task)).thenReturn(task);
         when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
@@ -1434,10 +1437,7 @@ public class TaskUpdateManagerTest {
     public void shouldUpdateTaskToRunningFromWorkersInRunning() {
         Task task = getStubTask(maxExecutionTime);
         task.changeStatus(INITIALIZED);
-
-        when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
-        when(replicatesService.getNbReplicatesWithCurrentStatus(
-                CHAIN_TASK_ID,
+        final ReplicateStatus[] acceptableStatus = new ReplicateStatus[]{
                 ReplicateStatus.STARTED,
                 ReplicateStatus.APP_DOWNLOADING,
                 ReplicateStatus.APP_DOWNLOAD_FAILED,
@@ -1450,7 +1450,12 @@ public class TaskUpdateManagerTest {
                 ReplicateStatus.COMPUTED,
                 ReplicateStatus.CONTRIBUTING,
                 ReplicateStatus.CONTRIBUTE_FAILED,
-                ReplicateStatus.CONTRIBUTED)).thenReturn(3);
+                ReplicateStatus.CONTRIBUTED
+        };
+
+        when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
+        when(replicatesService.getNbReplicatesWithLastRelevantStatus(task.getChainTaskId(), acceptableStatus))
+                .thenReturn(3);
         when(replicatesService.getNbReplicatesWithCurrentStatus(CHAIN_TASK_ID, ReplicateStatus.COMPUTED)).thenReturn(0);
 
         taskUpdateManager.updateTask(task.getChainTaskId());
@@ -1462,10 +1467,7 @@ public class TaskUpdateManagerTest {
     public void shouldUpdateTaskToRunningFromWorkersInRunningAndComputed() {
         Task task = getStubTask(maxExecutionTime);
         task.changeStatus(INITIALIZED);
-
-        when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
-        when(replicatesService.getNbReplicatesWithCurrentStatus(
-                CHAIN_TASK_ID,
+        final ReplicateStatus[] acceptableStatus = new ReplicateStatus[]{
                 ReplicateStatus.STARTED,
                 ReplicateStatus.APP_DOWNLOADING,
                 ReplicateStatus.APP_DOWNLOAD_FAILED,
@@ -1478,7 +1480,12 @@ public class TaskUpdateManagerTest {
                 ReplicateStatus.COMPUTED,
                 ReplicateStatus.CONTRIBUTING,
                 ReplicateStatus.CONTRIBUTE_FAILED,
-                ReplicateStatus.CONTRIBUTED)).thenReturn(4);
+                ReplicateStatus.CONTRIBUTED
+        };
+
+        when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
+        when(replicatesService.getNbReplicatesWithLastRelevantStatus(task.getChainTaskId(), acceptableStatus))
+                .thenReturn(4);
         when(replicatesService.getNbReplicatesWithCurrentStatus(CHAIN_TASK_ID, ReplicateStatus.COMPUTED)).thenReturn(2);
 
         taskUpdateManager.updateTask(task.getChainTaskId());

--- a/src/test/java/com/iexec/core/task/TaskUpdateManagerTest.java
+++ b/src/test/java/com/iexec/core/task/TaskUpdateManagerTest.java
@@ -411,15 +411,18 @@ public class TaskUpdateManagerTest {
 
         when(replicatesService.getNbReplicatesWithCurrentStatus(
                 task.getChainTaskId(),
-                ReplicateStatus.STARTING,
                 ReplicateStatus.STARTED,
                 ReplicateStatus.APP_DOWNLOADING,
+                ReplicateStatus.APP_DOWNLOAD_FAILED,
                 ReplicateStatus.APP_DOWNLOADED,
                 ReplicateStatus.DATA_DOWNLOADING,
+                ReplicateStatus.DATA_DOWNLOAD_FAILED,
                 ReplicateStatus.DATA_DOWNLOADED,
                 ReplicateStatus.COMPUTING,
+                ReplicateStatus.COMPUTE_FAILED,
                 ReplicateStatus.COMPUTED,
                 ReplicateStatus.CONTRIBUTING,
+                ReplicateStatus.CONTRIBUTE_FAILED,
                 ReplicateStatus.CONTRIBUTED)).thenReturn(2);
         when(replicatesService.getNbReplicatesWithCurrentStatus(task.getChainTaskId(), ReplicateStatus.COMPUTED)).thenReturn(0);
         when(taskRepository.save(task)).thenReturn(task);
@@ -1435,15 +1438,18 @@ public class TaskUpdateManagerTest {
         when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
         when(replicatesService.getNbReplicatesWithCurrentStatus(
                 CHAIN_TASK_ID,
-                ReplicateStatus.STARTING,
                 ReplicateStatus.STARTED,
                 ReplicateStatus.APP_DOWNLOADING,
+                ReplicateStatus.APP_DOWNLOAD_FAILED,
                 ReplicateStatus.APP_DOWNLOADED,
                 ReplicateStatus.DATA_DOWNLOADING,
+                ReplicateStatus.DATA_DOWNLOAD_FAILED,
                 ReplicateStatus.DATA_DOWNLOADED,
                 ReplicateStatus.COMPUTING,
+                ReplicateStatus.COMPUTE_FAILED,
                 ReplicateStatus.COMPUTED,
                 ReplicateStatus.CONTRIBUTING,
+                ReplicateStatus.CONTRIBUTE_FAILED,
                 ReplicateStatus.CONTRIBUTED)).thenReturn(3);
         when(replicatesService.getNbReplicatesWithCurrentStatus(CHAIN_TASK_ID, ReplicateStatus.COMPUTED)).thenReturn(0);
 
@@ -1460,15 +1466,18 @@ public class TaskUpdateManagerTest {
         when(taskService.getTaskByChainTaskId(CHAIN_TASK_ID)).thenReturn(Optional.of(task));
         when(replicatesService.getNbReplicatesWithCurrentStatus(
                 CHAIN_TASK_ID,
-                ReplicateStatus.STARTING,
                 ReplicateStatus.STARTED,
                 ReplicateStatus.APP_DOWNLOADING,
+                ReplicateStatus.APP_DOWNLOAD_FAILED,
                 ReplicateStatus.APP_DOWNLOADED,
                 ReplicateStatus.DATA_DOWNLOADING,
+                ReplicateStatus.DATA_DOWNLOAD_FAILED,
                 ReplicateStatus.DATA_DOWNLOADED,
                 ReplicateStatus.COMPUTING,
+                ReplicateStatus.COMPUTE_FAILED,
                 ReplicateStatus.COMPUTED,
                 ReplicateStatus.CONTRIBUTING,
+                ReplicateStatus.CONTRIBUTE_FAILED,
                 ReplicateStatus.CONTRIBUTED)).thenReturn(4);
         when(replicatesService.getNbReplicatesWithCurrentStatus(CHAIN_TASK_ID, ReplicateStatus.COMPUTED)).thenReturn(2);
 


### PR DESCRIPTION
  - it should transition for all replicate running status to avoid soft locks