### PR TITLE
Bugfix/too many contribution deadline detector calls

### DIFF
--- a/src/main/java/com/iexec/core/replicate/ReplicateSupplyService.java
+++ b/src/main/java/com/iexec/core/replicate/ReplicateSupplyService.java
@@ -239,6 +239,7 @@ public class ReplicateSupplyService {
                 break;
             case PLEASE_ABORT:
                 taskNotificationExtra.setTaskAbortCause(getTaskAbortCause(task));
+                break;
             default:
                 break;
         }

--- a/src/main/java/com/iexec/core/replicate/ReplicateSupplyService.java
+++ b/src/main/java/com/iexec/core/replicate/ReplicateSupplyService.java
@@ -114,7 +114,9 @@ public class ReplicateSupplyService {
         List<Task> validTasks = runningTasks.stream()
                 .filter(task -> ! task.isContributionDeadlineReached())
                 .collect(Collectors.toCollection(ArrayList::new));
-        if (validTasks.size() != runningTasks.size()) contributionTimeoutTaskDetector.detect();
+        if (validTasks.size() != runningTasks.size()) {
+            contributionTimeoutTaskDetector.detect();
+        }
 
         Optional<Worker> optional = workerService.getWorker(walletAddress);
         if (optional.isEmpty()) {

--- a/src/main/java/com/iexec/core/replicate/ReplicateSupplyService.java
+++ b/src/main/java/com/iexec/core/replicate/ReplicateSupplyService.java
@@ -112,15 +112,9 @@ public class ReplicateSupplyService {
 
         // filter the Tasks that have reached the contribution deadline
         List<Task> validTasks = runningTasks.stream()
-                .filter(task -> {
-                    if (task.isContributionDeadlineReached()) {
-                        contributionTimeoutTaskDetector.detect();
-                        return false;
-                    } else {
-                        return true;
-                    }
-                })
+                .filter(task -> ! task.isContributionDeadlineReached())
                 .collect(Collectors.toCollection(ArrayList::new));
+        if (validTasks.size() != runningTasks.size()) contributionTimeoutTaskDetector.detect();
 
         Optional<Worker> optional = workerService.getWorker(walletAddress);
         if (optional.isEmpty()) {

--- a/src/test/java/com/iexec/core/replicate/ReplicateSupplyServiceTests.java
+++ b/src/test/java/com/iexec/core/replicate/ReplicateSupplyServiceTests.java
@@ -349,8 +349,9 @@ class ReplicateSupplyServiceTests {
         replicateSupplyService.getAuthOfAvailableReplicate(workerLastBlock, WALLET_WORKER_1);
 
         // the call should only happen once over the two tasks
-        Mockito.verify(taskUpdateManager, Mockito.times(1))
-                .isConsensusReached(any());
+        Mockito.verify(contributionTimeoutTaskDetector).detect();
+        Mockito.verify(taskUpdateManager).isConsensusReached(task1);
+        Mockito.verify(taskUpdateManager, Mockito.never()).isConsensusReached(taskDeadlineReached);
     }
 
     @Test


### PR DESCRIPTION
Fix a call to ContributionTimeoutTaskDetector done for every task detected.
A single call is sufficient.