### PR TITLE
Add a fix for `TASK_NOT_ACTIVE`

### DIFF
--- a/src/main/java/com/iexec/core/replicate/ReplicateSupplyService.java
+++ b/src/main/java/com/iexec/core/replicate/ReplicateSupplyService.java
@@ -128,10 +128,11 @@ public class ReplicateSupplyService {
 
         for (Task task : validTasks) {
             String chainTaskId = task.getChainTaskId();
+            final List<Replicate> replicates = replicatesService.getReplicates(chainTaskId);
 
             // no need to go further if the consensus is already reached on-chain
             // the task should be updated since the consensus is reached but it is still in RUNNING status
-            if (taskUpdateManager.isConsensusReached(task)) {
+            if (taskUpdateManager.isConsensusReached(chainTaskId, replicates)) {
                 taskUpdateManager.publishUpdateTaskRequest(chainTaskId);
                 continue;
             }
@@ -162,7 +163,6 @@ public class ReplicateSupplyService {
                 continue;
             }
 
-            final List<Replicate> replicates = replicatesService.getReplicates(chainTaskId);
             final boolean taskNeedsMoreContributions = ConsensusHelper.doesTaskNeedMoreContributionsForConsensus(
                     chainTaskId,
                     replicates,
@@ -339,8 +339,8 @@ public class ReplicateSupplyService {
                 .equals(ReplicateStatus.CONTRIBUTED);
 
         if (didReplicateContribute) {
-
-            if (!taskUpdateManager.isConsensusReached(task)) {
+            final List<Replicate> replicates = replicatesService.getReplicates(chainTaskId);
+            if (!taskUpdateManager.isConsensusReached(chainTaskId, replicates)) {
                 return Optional.of(TaskNotificationType.PLEASE_WAIT);
             }
 

--- a/src/main/java/com/iexec/core/replicate/ReplicatesService.java
+++ b/src/main/java/com/iexec/core/replicate/ReplicatesService.java
@@ -168,9 +168,9 @@ public class ReplicatesService {
         return addressReplicates.size();
     }
 
-    public int getNbValidContributedWinners(String chainTaskId, String contributionHash) {
+    public int getNbValidContributedWinners(List<Replicate> replicates, String contributionHash) {
         int nbValidWinners = 0;
-        for (Replicate replicate : getReplicates(chainTaskId)) {
+        for (Replicate replicate : replicates) {
             Optional<ReplicateStatus> oStatus = replicate.getLastRelevantStatus();
             if (oStatus.isPresent() && oStatus.get().equals(CONTRIBUTED)
                     && contributionHash.equals(replicate.getContributionHash())) {

--- a/src/test/java/com/iexec/core/replicate/ReplicateServiceTests.java
+++ b/src/test/java/com/iexec/core/replicate/ReplicateServiceTests.java
@@ -381,7 +381,7 @@ public class ReplicateServiceTests {
                 .thenReturn(Optional.of(replicatesList));
 
         assertThat(replicatesService.getNbValidContributedWinners(
-                CHAIN_TASK_ID,
+                replicatesList.getReplicates(),
                 contributionHash
         )).isOne();        
     }


### PR DESCRIPTION
Replicates list should be entirely fixed in `ReplicateSupplyService#getAuthOfAvailableReplicate`.